### PR TITLE
Include license, optional noarch:python

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,7 @@
   "repo_name": "repository_name",
   "package_name": "{{ cookiecutter.repo_name.lower().replace(' ', '_') }}",
   "project_short_description": "Short description",
-  "noarch_python": "True",
+  "noarch_python": "y",
+  "include_cli": "y",
   "open_source_license": ["MIT", "BSD", "ISC", "Apache", "GNUv3", "Proprietary"]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,5 +4,7 @@
   "github_username": "Destination github org or username",
   "repo_name": "repository_name",
   "package_name": "{{ cookiecutter.repo_name.lower().replace(' ', '_') }}",
-  "project_short_description": "Short description"
+  "project_short_description": "Short description",
+  "noarch_python": "True",
+  "open_source_license": ["MIT", "BSD", "ISC", "Apache", "GNUv3", "Proprietary"]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -11,3 +11,8 @@ if __name__ == '__main__':
 
     if '{{ cookiecutter.open_source_license }}' == 'Proprietary':
         remove_file('LICENSE')
+
+    if '{{ cookiecutter.include_cli }}' != 'y':
+        remove_file('{{ cookiecutter.package_name }}/__main__.py')
+        remove_file('{{ cookiecutter.package_name }}/cli.py')
+        remove_file('tests/test_cli.py')

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import os
+
+PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)
+
+
+def remove_file(filepath):
+    os.remove(os.path.join(PROJECT_DIRECTORY, filepath))
+
+if __name__ == '__main__':
+
+    if '{{ cookiecutter.open_source_license }}' == 'Proprietary':
+        remove_file('LICENSE')

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.fixture
-def context():
+def base_context():
     """Test template creation with test parameters."""
     return {
         "full_name": "test name",
@@ -11,20 +11,82 @@ def context():
         "repo_name": "test_repo",
         "package_name": "test_repo",
         "project_short_description": "Test description.",
-        "version": "0.1.0"
+        "version": "0.1.0",
     }
 
 
-def test_template(cookies, context):
+def test_template(cookies, base_context):
     """Test the template for proper creation.
-    
+
     cookies is a fixture provided by the pytest-cookies
     plugin. Its bake() method creates a temporary directory
-    and installs the cookiecutter template into that directory. 
+    and installs the cookiecutter template into that directory.
     """
-    result = cookies.bake(extra_context=context)
+    result = cookies.bake(extra_context=base_context)
 
     assert result.exit_code == 0
     assert result.exception is None
     assert result.project.basename == 'test_repo'
     assert result.project.isdir()
+
+
+def test_has_license(cookies):
+    context = {
+        "full_name": "test name",
+        "email": "test@email.com",
+        "github_username": "test_username",
+        "repo_name": "test_repo",
+        "package_name": "test_repo",
+        "project_short_description": "Test description.",
+        "version": "0.1.0",
+        "open_source_license": "BSD"
+    }
+    result = cookies.bake(extra_context=context)
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.project.join('LICENSE').check(file=1)
+
+
+def test_no_license(cookies):
+    context = {
+        "full_name": "test name",
+        "email": "test@email.com",
+        "github_username": "test_username",
+        "repo_name": "test_repo",
+        "package_name": "test_repo",
+        "project_short_description": "Test description.",
+        "version": "0.1.0",
+        "open_source_license": "Proprietary"
+    }
+    result = cookies.bake(extra_context=context)
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert not result.project.join('LICENSE').check(file=1)
+
+def test_noararch(cookies):
+    context = {
+        "full_name": "test name",
+        "email": "test@email.com",
+        "github_username": "test_username",
+        "repo_name": "test_repo",
+        "package_name": "test_repo",
+        "project_short_description": "Test description.",
+        "version": "0.1.0",
+        "open_source_license": "Proprietary",
+        "noarch_python": "True"
+    }
+    result = cookies.bake(extra_context=context)
+    assert result.exit_code == 0
+    assert result.exception is None
+    with result.project.join('conda.recipe','meta.yaml').open() as f:
+        recipe = f.read()
+        assert "noarch: python" in recipe
+
+    context['noarch_python'] = 'False'
+    result = cookies.bake(extra_context=context)
+    assert result.exit_code == 0
+    assert result.exception is None
+    with result.project.join('conda.recipe','meta.yaml').open() as f:
+        recipe = f.read()
+        assert "noarch: python" not in recipe
+

--- a/{{cookiecutter.repo_name}}/LICENSE
+++ b/{{cookiecutter.repo_name}}/LICENSE
@@ -1,0 +1,111 @@
+{% if cookiecutter.open_source_license == 'MIT' -%}
+MIT License
+
+Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+{% elif cookiecutter.open_source_license == 'BSD' %}
+
+BSD License
+
+Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+{% elif cookiecutter.open_source_license == 'ISC' -%}
+ISC License
+
+Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+{% elif cookiecutter.open_source_license == 'Apache' -%}
+Apache Software License 2.0
+
+Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.full_name }}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% elif cookiecutter.open_source_license == 'GNUv3' -%}
+GNU GENERAL PUBLIC LICENSE
+                      Version 3, 29 June 2007
+
+    {{ cookiecutter.project_short_description }}
+    Copyright (C) {% now 'local', '%Y' %}  {{ cookiecutter.full_name }}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+{% endif %}

--- a/{{cookiecutter.repo_name}}/conda.recipe/meta.yaml
+++ b/{{cookiecutter.repo_name}}/conda.recipe/meta.yaml
@@ -21,8 +21,16 @@ build:
   {% raw -%}
   script: {{ PYTHON }} -m pip install --no-deps --ignore-installed -vv .
   {%- endraw %}
-  {% if cookiecutter.noarch_python == 'True' -%}
+  {% if cookiecutter.noarch_python == 'y' -%}
   noarch: python
+  {% endif %}
+  {% if cookiecutter.include_cli == 'y' -%}
+  {% raw -%}
+  entry_points:
+    {% for entry in setup_py['entry_points']['console_scripts'] %}
+      - {{ entry.split('=')[0].strip() }} = {{ entry.split('=')[1].strip() }}
+    {% endfor %}
+  {%- endraw %}
   {% endif %}
 
 requirements:

--- a/{{cookiecutter.repo_name}}/conda.recipe/meta.yaml
+++ b/{{cookiecutter.repo_name}}/conda.recipe/meta.yaml
@@ -18,7 +18,12 @@ build:
   # separate bld.bat and build.sh files instead of this key.  Add the line
   # "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or
   # "skip: True  # [not win]" to limit to Windows.
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  {% raw -%}
+  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed -vv .
+  {%- endraw %}
+  {% if cookiecutter.noarch_python == 'True' -%}
+  noarch: python
+  {% endif %}
 
 requirements:
   build:
@@ -46,3 +51,7 @@ test:
 about:
   home: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}
   summary: {{ cookiecutter.project_short_description }}
+  {% raw -%}
+  license: {{ setup_py.get('license') }}
+  {%- endraw %}
+  license_file: LICENSE

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -25,5 +25,6 @@ setup(
     classifiers=[
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -10,6 +10,7 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     description="{{ cookiecutter.project_short_description }}",
+    license="{{ cookiecutter.open_source_license }}",
     author="{{ cookiecutter.full_name.replace('\"', '\\\"') }}",
     author_email='{{ cookiecutter.email }}',
     url='https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}',

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -15,11 +15,13 @@ setup(
     author_email='{{ cookiecutter.email }}',
     url='https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}',
     packages=['{{ cookiecutter.package_name }}'],
+    {% if cookiecutter.include_cli == "y" -%}
     entry_points={
         'console_scripts': [
             '{{ cookiecutter.package_name }}={{ cookiecutter.package_name }}.cli:cli'
         ]
     },
+    {%- endif %}
     install_requires=requirements,
     keywords='{{ cookiecutter.repo_name }}',
     classifiers=[

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.package_name}}/__init__.py
@@ -1,0 +1,3 @@
+from ._version import get_versions
+__version__ = get_versions()['version']
+del get_versions


### PR DESCRIPTION
This PR provide the following updates
* Utilize new pip-based script in build section
* provide license file
* Set the cli as optional
* Set `noarch: python` as optional
* set `__version__` attribute

Tests are provided for the new optional parameters
