### PR TITLE
Update meta.yaml

### DIFF
--- a/{{cookiecutter.repo_name}}/conda.recipe/meta.yaml
+++ b/{{cookiecutter.repo_name}}/conda.recipe/meta.yaml
@@ -66,6 +66,6 @@ about:
   home: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}
   summary: {{ cookiecutter.project_short_description }}
   {% raw -%}
-  license: {{ setup_py.get('license') }}
+  license: {{ data['license'] }}
   {%- endraw %}
   license_file: LICENSE

--- a/{{cookiecutter.repo_name}}/conda.recipe/meta.yaml
+++ b/{{cookiecutter.repo_name}}/conda.recipe/meta.yaml
@@ -27,7 +27,7 @@ build:
   {% if cookiecutter.include_cli == 'y' -%}
   {% raw -%}
   entry_points:
-    {% for entry in setup_py['entry_points']['console_scripts'] %}
+    {% for entry in data['entry_points']['console_scripts'] %}
       - {{ entry.split('=')[0].strip() }} = {{ entry.split('=')[1].strip() }}
     {% endfor %}
   {%- endraw %}


### PR DESCRIPTION
license
TypeError: 'NoneType' object is not callable