### PR TITLE
Fix bug accessing setup.py info and minor cleanups around "raw"

### DIFF
--- a/{{cookiecutter.repo_name}}/conda.recipe/meta.yaml
+++ b/{{cookiecutter.repo_name}}/conda.recipe/meta.yaml
@@ -27,7 +27,7 @@ build:
   {% if cookiecutter.include_cli == 'y' -%}
   {% raw -%}
   entry_points:
-    {% for entry in setup_py['entry_points']['console_scripts'] %}
+    {% for entry in data['entry_points']['console_scripts'] %}
       - {{ entry.split('=')[0].strip() }} = {{ entry.split('=')[1].strip() }}
     {% endfor %}
   {%- endraw %}
@@ -66,6 +66,6 @@ about:
   home: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}
   summary: {{ cookiecutter.project_short_description }}
   {% raw -%}
-  license: {{ setup_py.get('license') }}
+  license: {{ data.get('license') }}
   {%- endraw %}
   license_file: LICENSE

--- a/{{cookiecutter.repo_name}}/conda.recipe/meta.yaml
+++ b/{{cookiecutter.repo_name}}/conda.recipe/meta.yaml
@@ -1,11 +1,11 @@
-{# raw is for ignoring templating with cookiecutter, leaving it for use with conda-build #}
+{# raw is for ignoring templating with cookiecutter, leaving it for use with conda-build -#}
 {% raw -%}
 {% set data = load_setup_py_data() %}
 {%- endraw %}
 
 package:
   name: {{ cookiecutter.package_name }}
-  {# raw is for ignoring templating with cookiecutter, leaving it for use with conda-build #}
+  {# raw is for ignoring templating with cookiecutter, leaving it for use with conda-build -#}
   {% raw -%}
   version: {{ data['version'] }}
   {%- endraw %}
@@ -45,12 +45,12 @@ requirements:
     - pip
   run:
     - python
+    {# raw is for ignoring templating with cookiecutter, leaving it for use with conda-build -#}
     {% raw -%}
     # dependencies are defined in setup.py
     {% for dep in data['install_requires'] %}
     - {{ dep.lower() }}
     {% endfor %}
-    {# raw is for ignoring templating with cookiecutter, leaving it for use with conda-build #}
     {%- endraw %}
 
 test:


### PR DESCRIPTION
I found an issue with how the meta.yaml cookie-cutter file was accessing the data from the setup.py file. When I went to report it I found someone already had (#19) and further than someone had made a pull request to close it (#21). Since @luyang93 hadn't signed the CLA yet, I went ahead and did that so we can get the bug fixed.

I also noticed a comment about the jinja2 raw block that was slipping through into the meta.yaml. I fixed this and got rid of the blank lines that the comments were leaving in the meta.yaml file.