### PR TITLE
Prevent pytest config warnings

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -11,10 +11,8 @@ addopts =
     --ignore run_test.py
     --cov-report term-missing
     --tb native
-    --strict
+    --strict-markers
     --durations=20
-env =
-    PYTHONHASHSEED=0
 markers =
     serial: execute test serially (to avoid race conditions)
 


### PR DESCRIPTION
- `--strict` triggered `PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.`
- `env` triggered `PytestConfigWarning: Unknown config option: env`